### PR TITLE
Do not throw error on empty spaces in the file name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shelf/aws-lambda-libreoffice",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "92 MB LibreOffice to fit inside AWS Lambda compressed with Brotli",
   "keywords": [
     "aws lambda",

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -1,8 +1,9 @@
-import {execSync} from 'child_process';
-import {basename} from 'path';
-import {unpack} from './unpack';
-import {cleanupTempFiles} from './cleanup';
-import {getConvertedFilePath} from './logs';
+import { execSync } from 'child_process';
+import { basename } from 'path';
+
+import { cleanupTempFiles } from './cleanup';
+import { getConvertedFilePath } from './logs';
+import { unpack } from './unpack';
 
 export const defaultArgs = [
   '--headless',
@@ -51,7 +52,7 @@ export async function convertTo(
 
   const cmd = `cd /tmp && ${OUTPUT_PATH} ${defaultArgs.join(
     ' '
-  )} --convert-to ${format} --outdir /tmp /tmp/${filename}`;
+  )} --convert-to ${format} --outdir /tmp /tmp/${filename.split(/\ /).join('\ ')}`;
   // due to unknown issue, we need to run command twice
   try {
     logs = execSync(cmd);
@@ -59,7 +60,7 @@ export async function convertTo(
     logs = execSync(cmd);
   }
 
-  execSync(`rm /tmp/${filename}`);
+  execSync(`rm /tmp/${filename.split(/\ /).join('\ ')}`);
   cleanupTempFiles();
 
   return getConvertedFilePath(logs.toString('utf8'));


### PR DESCRIPTION
Empty spaces in file names no longer breaks the "rm" command.