### PR TITLE
chore!: upgrade LibreOffice to version 7.4

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ $ yarn add @shelf/aws-lambda-libreoffice
 ## Features
 
 - Includes CJK and X11 fonts bundled in the [base Docker image](https://github.com/shelfio/libreoffice-lambda-base-image)!
-- Relies on the latest LibreOffice 7.3 version which is not stripped down from features as a previous layer-based version of this package
+- Relies on the latest LibreOffice 7.4 version which is not stripped down from features as a previous layer-based version of this package
 - Requires node.js 16x runtime (x86_64)
 
 ## Requirements
@@ -24,7 +24,7 @@ See the example at [libreoffice-lambda-base-image](https://github.com/shelfio/li
 Example:
 
 ```Dockerfile
-FROM public.ecr.aws/shelf/lambda-libreoffice-base:7.3-node16-x86_64
+FROM public.ecr.aws/shelf/lambda-libreoffice-base:7.4-node16-x86_64
 
 COPY ./ ${LAMBDA_TASK_ROOT}/
 

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -11,7 +11,7 @@ export const DEFAULT_ARGS = [
   '--nologo',
   '--norestore',
 ];
-const LO_BINARY_PATH = 'libreoffice7.3';
+const LO_BINARY_PATH = 'libreoffice7.4';
 
 export function convertTo(filename: string, format: string): string {
   cleanupTempFiles();


### PR DESCRIPTION
Should be merged only after https://github.com/shelfio/libreoffice-lambda-base-image/pull/9 is merged and the image is pushed to the ECR