### PR TITLE
put ticks around filenames to allow spaces

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -19,7 +19,7 @@ export function convertTo(filename: string, format: string): string {
   const argumentsString = DEFAULT_ARGS.join(' ');
   const outputFilename = filename.split(/\\ /).join(' ');
 
-  const cmd = `cd /tmp && ${LO_BINARY_PATH} ${argumentsString} --convert-to ${format} --outdir /tmp /tmp/${outputFilename}`;
+  const cmd = `cd /tmp && ${LO_BINARY_PATH} ${argumentsString} --convert-to ${format} --outdir /tmp '/tmp/${outputFilename}'`;
 
   let logs;
 
@@ -30,7 +30,7 @@ export function convertTo(filename: string, format: string): string {
     logs = execSync(cmd);
   }
 
-  execSync(`rm /tmp/${outputFilename}`);
+  execSync(`rm '/tmp/${outputFilename}'`);
   cleanupTempFiles();
 
   return getConvertedFilePath(logs.toString());


### PR DESCRIPTION
First: Thanks for your great work!

Surprised that I was the first to have this issue(?)
without the ticks when using a filename with spaces I received a.o. 

 ```
  Error: Command failed: rm /tmp/filename with spaces.docx 
  rm: cannot remove ‘/tmp/filename’: No such file or directory 
  rm: cannot remove ‘with’: No such file or directory 
  rm: cannot remove ‘spaces.docx’: No such file or directory

    at checkExecSyncError (node:child_process:861:11)
    at execSync (node:child_process:932:15)
    at convertTo (/var/task/node_modules/@shelf/aws-lambda-libreoffice/lib/convert.js:32:31)
```

and also the log could not locate the file so added ticks there as well.

Please correct me if I missed something. Happy holiday season!