### PR TITLE
Allow custom LibreOffice binary path via environment variable

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -14,7 +14,7 @@ export const DEFAULT_ARGS = [
   '--nologo',
   '--norestore',
 ];
-const LO_BINARY_PATH = 'libreoffice7.6';
+const LO_BINARY_PATH = process.env.LO_BINARY_PATH ?? 'libreoffice7.6';
 
 export async function convertTo(filename: string, format: string): Promise<string> {
   await cleanupTempFiles();


### PR DESCRIPTION
I would like to update the LibreOffice version in [shelfio/libreoffice-lambda-base-image](https://github.com/shelfio/libreoffice-lambda-base-image). However, since the LibreOffice binary version and path are hardcoded in the following location, if there is an application already in operation, changes need to be applied simultaneously to both repositories, making it challenging to upgrade the version.
https://github.com/shelfio/aws-lambda-libreoffice/blob/6e23c3c3382c2c9829b50982a718fceeacce83e9/src/convert.ts#L17

With this PR, the `LO_BINARY_PATH` environment variable allows injecting the version and path of LibreOffice, simplifying the upgrade process.